### PR TITLE
Add a page title tag

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -12,6 +12,7 @@ import { ContentWrapper } from "./components/ContentWrapper";
 import { ThemeProvider } from "@/components/providers/ThemeProvider";
 import { XeTooltip } from "@/components/helpers/Tooltip";
 import { DarkModeToggle } from "./components/DarkModeToggle";
+import { Metadata } from "next";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -20,6 +21,10 @@ if (process.env.NODE_ENV !== "production") {
   loadDevMessages();
   loadErrorMessages();
 }
+
+export const metadata: Metadata = {
+  title: "Sitecore XE Browser",
+};
 
 export default function RootLayout({ children }: React.PropsWithChildren) {
   return (


### PR DESCRIPTION
This will add a title tag inside the head of a page. 

Screenshot:
![image](https://github.com/horizontalintegration/xe-browser/assets/4261360/f778d3dd-340b-44cd-8466-7ce6dffc530e)

